### PR TITLE
Ringbuffer experiment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,7 +588,6 @@ impl<T: Trait> Module<T> {
 	fn bonds_transient() -> Box<
 		dyn RingBufferTrait<
 			Bond<T::AccountId, T::BlockNumber>,
-			Item = Bond<T::AccountId, T::BlockNumber>,
 			Bounds = <Self as Store>::BondsRange,
 			Map = <Self as Store>::Bonds,
 		>,
@@ -599,7 +598,6 @@ impl<T: Trait> Module<T> {
 			<Self as Store>::Bonds,
 			dyn RingBufferTrait<
 				Bond<T::AccountId, T::BlockNumber>,
-				Item = Bond<T::AccountId, T::BlockNumber>,
 				Bounds = <Self as Store>::BondsRange,
 				Map = <Self as Store>::Bonds,
 			>,
@@ -613,7 +611,6 @@ impl<T: Trait> Module<T> {
 		for bond in bonds_to_push {
 			bonds.push(bond);
 		}
-		bonds.commit();
 	}
 
 	// ------------------------------------------------------------
@@ -664,7 +661,6 @@ impl<T: Trait> Module<T> {
 				break;
 			}
 		}
-		bonds.commit();
 		// safe to do this late because of the test in the first line of the function
 		// safe to substrate remaining because we initialize it with amount and never increase it
 		let new_supply = coin_supply + amount - remaining;
@@ -884,7 +880,6 @@ mod tests {
 	// Trait object that we will be interacting with.
 	type RingBuffer = dyn RingBufferTrait<
 		BondT,
-		Item = BondT,
 		Bounds = <Stablecoin as Store>::BondsRange,
 		Map = <Stablecoin as Store>::Bonds,
 	>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,10 @@ use sp_std::collections::vec_deque::VecDeque;
 use sp_std::iter;
 use system::ensure_signed;
 
-mod utils;
 mod ringbuffer;
+mod utils;
 
+use ringbuffer::{RingBufferTrait, RingBufferTransient};
 use utils::saturated_mul;
 
 /// Expected price oracle interface. `fetch_price` must return the amount of coins exchanged for the tracked value.
@@ -584,55 +585,35 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
+	fn bonds_transient() -> Box<
+		dyn RingBufferTrait<
+			Bond<T::AccountId, T::BlockNumber>,
+			Item = Bond<T::AccountId, T::BlockNumber>,
+			Bounds = <Self as Store>::BondsRange,
+			Map = <Self as Store>::Bonds,
+		>,
+	> {
+		Box::new(RingBufferTransient::<
+			Bond<T::AccountId, T::BlockNumber>,
+			<Self as Store>::BondsRange,
+			<Self as Store>::Bonds,
+			dyn RingBufferTrait<
+				Bond<T::AccountId, T::BlockNumber>,
+				Item = Bond<T::AccountId, T::BlockNumber>,
+				Bounds = <Self as Store>::BondsRange,
+				Map = <Self as Store>::Bonds,
+			>,
+		>::new())
+	}
+
 	/// Push several bonds into the queue.
-	fn push_bonds(bonds: VecDeque<Bond<T::AccountId, T::BlockNumber>>) {
-		let (prev_bonds_start, prev_bonds_end) = Self::bonds_range();
-		let mut start_end = (prev_bonds_start, prev_bonds_end);
-		for bond in bonds {
-			start_end = Self::push_bond(start_end, bond);
-		}
-		<BondsRange>::put(start_end);
-	}
+	fn push_bonds(bonds_to_push: VecDeque<Bond<T::AccountId, T::BlockNumber>>) {
+		let mut bonds = Self::bonds_transient();
 
-	/// Push a bond into the queue to be payed out at a later date.
-	///
-	/// Returns the new end index of the bonds queue.
-	fn push_bond(
-		(bonds_start, bonds_end): (BondIndex, BondIndex),
-		bond: Bond<T::AccountId, T::BlockNumber>,
-	) -> (BondIndex, BondIndex) {
-		<Bonds<T>>::insert(bonds_end, bond);
-		// this will intentionally overflow and wrap around when bonds_end
-		// reaches `BondIndex::max_value` because we want a ringbuffer.
-		let next_index = bonds_end.wrapping_add(1);
-		if next_index == bonds_start {
-			// overwrite the oldest item in the FIFO ringbuffer
-			(bonds_start.wrapping_add(1), next_index)
-		} else {
-			(bonds_start, next_index)
+		for bond in bonds_to_push {
+			bonds.push(bond);
 		}
-	}
-
-	fn pop_bond(
-		(bonds_start, bonds_end): (BondIndex, BondIndex),
-	) -> ((BondIndex, BondIndex), Option<Bond<T::AccountId, T::BlockNumber>>) {
-		if bonds_start == bonds_end {
-			return ((bonds_start, bonds_end), None);
-		}
-		let bond = <Bonds<T>>::take(bonds_start);
-		((bonds_start.wrapping_add(1), bonds_end), bond.into())
-	}
-
-	fn push_bond_front(
-		(bonds_start, bonds_end): (BondIndex, BondIndex),
-		bond: Bond<T::AccountId, T::BlockNumber>,
-	) -> (BondIndex, BondIndex) {
-		if bonds_start == bonds_end {
-			return Self::push_bond((bonds_start, bonds_end), bond);
-		}
-		let index = bonds_start.wrapping_sub(1);
-		<Bonds<T>>::insert(index, bond);
-		(index, bonds_end)
+		bonds.commit();
 	}
 
 	// ------------------------------------------------------------
@@ -649,21 +630,14 @@ impl<T: Trait> Module<T> {
 			.ok_or(Error::<T>::CoinSupplyOverflow)?;
 		// ↑ verify ↑
 		let mut remaining = amount;
-		let (prev_bonds_start, prev_bonds_end) = Self::bonds_range();
-		let mut start_end = (prev_bonds_start, prev_bonds_end);
-		let mut pop;
+		let mut bonds = Self::bonds_transient();
 		// ↓ update ↓
 		while let Some(Bond {
 			account,
 			payout,
 			expiration,
-		}) = if remaining > 0 {
-			pop = Self::pop_bond(start_end);
-			start_end = pop.0;
-			pop.1
-		} else {
-			None
-		} {
+		}) = if remaining > 0 { bonds.pop() } else { None }
+		{
 			// bond has expired --> discard
 			if <system::Module<T>>::block_number() >= expiration {
 				Self::deposit_event(RawEvent::BondExpired(account, payout));
@@ -681,23 +655,16 @@ impl<T: Trait> Module<T> {
 				// this is safe because we are in the else branch where payout > remaining
 				let payout = payout - remaining;
 				Self::add_balance(&account, remaining);
-				start_end = Self::push_bond_front(
-					start_end,
-					Bond {
-						account: account.clone(),
-						payout,
-						expiration,
-					},
-				);
+				bonds.push_front(Bond {
+					account: account.clone(),
+					payout,
+					expiration,
+				});
 				Self::deposit_event(RawEvent::BondPartiallyFulfilled(account, payout));
 				break;
 			}
 		}
-		let (bonds_start, mut bonds_end) = start_end;
-		if bonds_start == bonds_end && <Bonds<T>>::contains_key(bonds_start) {
-			bonds_end = bonds_end.wrapping_add(1);
-		}
-		<BondsRange>::put((bonds_start, bonds_end));
+		bonds.commit();
 		// safe to do this late because of the test in the first line of the function
 		// safe to substrate remaining because we initialize it with amount and never increase it
 		let new_supply = coin_supply + amount - remaining;
@@ -863,14 +830,17 @@ mod tests {
 		pub const MinimumSupply: u64 = BaseUnit::get();
 	}
 
+	type AccountId = u64;
+	type BlockNumber = u64;
+
 	impl system::Trait for Test {
 		type Origin = Origin;
 		type Call = ();
 		type Index = u64;
-		type BlockNumber = u64;
+		type BlockNumber = BlockNumber;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
-		type AccountId = u64;
+		type AccountId = AccountId;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
 		type Event = ();
@@ -910,10 +880,26 @@ mod tests {
 
 	// ------------------------------------------------------------
 	// utils
-	fn add_bond(bond: Bond<u64, u64>) {
-		let (start, end) = Stablecoin::bonds_range();
-		let (start, end) = Stablecoin::push_bond((start, end), bond);
-		<Stablecoin as crate::Store>::BondsRange::put((start, end));
+	type BondT = Bond<AccountId, BlockNumber>;
+	// Trait object that we will be interacting with.
+	type RingBuffer = dyn RingBufferTrait<
+		BondT,
+		Item = BondT,
+		Bounds = <Stablecoin as Store>::BondsRange,
+		Map = <Stablecoin as Store>::Bonds,
+	>;
+	// Implementation that we will instantiate.
+	type Transient = RingBufferTransient<
+		BondT,
+		<Stablecoin as Store>::BondsRange,
+		<Stablecoin as Store>::Bonds,
+		RingBuffer,
+	>;
+
+	fn add_bond(bond: BondT) {
+		let mut bonds: Box<RingBuffer> = Box::new(Transient::new());
+		bonds.push(bond);
+		bonds.commit();
 	}
 
 	// ------------------------------------------------------------
@@ -1074,86 +1060,6 @@ mod tests {
 				]
 			);
 		});
-	}
-
-	// ------------------------------------------------------------
-	// ringbuffer
-
-	#[test]
-	fn ringbuffer_push_bond() {
-		new_test_ext().execute_with(|| {
-			assert_ok!(Stablecoin::init(Origin::signed(1)));
-
-			let start_end = Stablecoin::bonds_range();
-			let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
-			let (start, end) = Stablecoin::push_bond(start_end, Stablecoin::new_bond(2, payout));
-			assert_eq!(start..end, 0..1);
-		})
-	}
-
-	#[test]
-	fn ringbuffer_pop_bond() {
-		new_test_ext().execute_with(|| {
-			assert_ok!(Stablecoin::init(Origin::signed(1)));
-
-			let start_end = Stablecoin::bonds_range();
-			let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
-			let (start, end) = Stablecoin::push_bond(start_end, Stablecoin::new_bond(2, payout));
-			assert_eq!(start..end, 0..1);
-
-			let ((start, end), bond) = Stablecoin::pop_bond((start, end));
-			assert!(bond.is_some());
-			assert_eq!(start..end, 1..1);
-		})
-	}
-
-	#[test]
-	fn ringbuffer_wrap_around() {
-		new_test_ext().execute_with(|| {
-			assert_ok!(Stablecoin::init(Origin::signed(1)));
-
-			let mut start_end = Stablecoin::bonds_range();
-			let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
-			for i in 1..(u16::max_value() as u64) + 2 {
-				start_end = Stablecoin::push_bond(start_end, Stablecoin::new_bond(i, payout));
-			}
-			assert_eq!(
-				start_end,
-				(1, 0),
-				"range should be inverted because the index wrapped around"
-			);
-
-			let ((start, end), bond) = Stablecoin::pop_bond(start_end);
-			assert_eq!(start..end, 2..0);
-			let bond = bond.expect("a valid bond should be returned");
-			assert_eq!(bond.account, 2, "the bond for account 2, was placed at index 1");
-
-			let ((start, end), bond) = Stablecoin::pop_bond((start, end));
-			assert_eq!(start..end, 3..0);
-			let bond = bond.expect("a valid bond should be returned");
-			assert_eq!(bond.account, 3, "the bond for account 3, was placed at index 2");
-
-			start_end = (start, end);
-			for i in 1..4 {
-				start_end = Stablecoin::push_bond(start_end, Stablecoin::new_bond(i, payout));
-			}
-			assert_eq!(start_end, (4, 3));
-		})
-	}
-
-	#[test]
-	fn ringbuffer_push_front() {
-		new_test_ext().execute_with(|| {
-			assert_ok!(Stablecoin::init(Origin::signed(1)));
-
-			let start_end = Stablecoin::bonds_range();
-			let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
-			let start_end = Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
-			assert_eq!(start_end, (0, 1));
-
-			let start_end = Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
-			assert_eq!(start_end, (u16::max_value(), 1));
-		})
 	}
 
 	// ------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1116,7 +1116,11 @@ mod tests {
 			for i in 1..(u16::max_value() as u64) + 2 {
 				start_end = Stablecoin::push_bond(start_end, Stablecoin::new_bond(i, payout));
 			}
-			assert_eq!(start_end, (1, 0), "range should be inverted because the index wrapped around");
+			assert_eq!(
+				start_end,
+				(1, 0),
+				"range should be inverted because the index wrapped around"
+			);
 
 			let ((start, end), bond) = Stablecoin::pop_bond(start_end);
 			assert_eq!(start..end, 2..0);
@@ -1146,11 +1150,11 @@ mod tests {
 			let start_end = Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
 			assert_eq!(start_end, (0, 1));
 
-			let start_end= Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
+			let start_end = Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
 			assert_eq!(start_end, (u16::max_value(), 1));
 		})
 	}
-	
+
 	// ------------------------------------------------------------
 	// bonds
 	#[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,7 +557,10 @@ impl<T: Trait> Module<T> {
 				bond.expiration,
 			));
 		}
-		Self::push_bonds(new_bonds);
+		let mut bonds = Self::bonds_transient();
+		for bond in new_bonds {
+			bonds.push(bond);
+		}
 		<CoinSupply>::put(new_supply);
 		<BondBids<T>>::put(bids);
 		Self::deposit_event(RawEvent::ContractedSupply(burned));
@@ -602,15 +605,6 @@ impl<T: Trait> Module<T> {
 				Map = <Self as Store>::Bonds,
 			>,
 		>::new())
-	}
-
-	/// Push several bonds into the queue.
-	fn push_bonds(bonds_to_push: VecDeque<Bond<T::AccountId, T::BlockNumber>>) {
-		let mut bonds = Self::bonds_transient();
-
-		for bond in bonds_to_push {
-			bonds.push(bond);
-		}
 	}
 
 	// ------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ use sp_std::iter;
 use system::ensure_signed;
 
 mod utils;
+mod ringbuffer;
 
 use utils::saturated_mul;
 

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -1,0 +1,271 @@
+use core::marker::PhantomData;
+use codec::{Codec, Encode, Decode, EncodeLike};
+use frame_support::storage::{StorageValue, StorageMap};
+
+pub type Index = u16;
+
+pub struct RingBufferTransient<T> {
+	start: Index,
+	end: Index,
+	_t: PhantomData<T>,
+}
+
+impl<T, I, B, M> RingBufferTransient<T>
+where
+	I: Codec + EncodeLike,
+	B: StorageValue<(Index, Index), Query = (Index, Index)>,
+	M: StorageMap<Index, I, Query = I>,
+	T: RingBufferTrait<I, B, M, Item = I, Bounds = B, Map = M>
+{
+
+	fn new() -> RingBufferTransient<T> {
+		let (start, end) = RingBufferTrait::Bounds::get();
+		RingBufferTransient {start, end, _t: PhantomData }
+	}
+}
+
+pub trait RingBufferTrait<I, B, M> 
+where
+	I: Codec + EncodeLike,
+{
+	type Item: Codec;
+	type Bounds: StorageValue<(Index, Index)>;
+	type Map: StorageMap<Index, I>;
+
+	fn commit(&self);
+
+	fn push(&mut self, i: Self::Item);
+	fn push_front(&mut self, i: Self::Item);
+
+	fn pop(&mut self) -> Option<Self::Item>;
+}
+
+impl<T, I, B, M> RingBufferTrait<I, B, M> for RingBufferTransient<T>
+where
+	I: Codec + EncodeLike,
+	B: StorageValue<(Index, Index), Query = (Index, Index)>,
+	M: StorageMap<Index, I, Query = I>,
+	T: RingBufferTrait<I, B, M>,
+{
+	type Item = I;
+	type Bounds = B;
+	type Map = M;
+
+	fn commit(&self) {
+		Self::Bounds::put((self.start, self.end));
+	}
+
+	/// Push a bond into the queue to be payed out at a later date.
+	///
+	/// Returns the new end index of the bonds queue.
+	fn push(&mut self, item: Self::Item) {
+		Self::Map::insert(self.end, item);
+		// this will intentionally overflow and wrap around when bonds_end
+		// reaches `Index::max_value` because we want a ringbuffer.
+		let next_index = self.end.wrapping_add(1);
+		if next_index == self.start {
+			// overwrite the oldest item in the FIFO ringbuffer
+			self.start = self.start.wrapping_add(1);
+			self.end = next_index;
+		} else {
+			self.end = next_index;
+		}
+	}
+
+	fn push_front(&mut self, item: Self::Item) {
+		if self.start == self.end {
+			<Self as RingBufferTrait<I, B, M>>::push(self, item);
+			return;
+		}
+		let index = self.start.wrapping_sub(1);
+		Self::Map::insert(index, item);
+		self.start = index;
+	}
+
+	fn pop(&mut self) -> Option<Self::Item> {
+		if self.start == self.end {
+			return None;
+		}
+		let item = Self::Map::take(self.start);
+		self.start = self.start.wrapping_add(1);
+		
+		item.into()
+	}
+}
+
+/// tests for this pallet
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use itertools::Itertools;
+	use log;
+	use more_asserts::*;
+	use quickcheck::{QuickCheck, TestResult};
+	use rand::{thread_rng, Rng};
+	use std::sync::atomic::{AtomicU64, Ordering};
+
+	use frame_support::{assert_ok, decl_module, decl_storage, impl_outer_origin, parameter_types, weights::Weight};
+	use sp_core::H256;
+	use sp_runtime::{
+		testing::Header,
+		traits::{BlakeTwo256, IdentityLookup},
+		Perbill,
+	};
+	use system;
+
+	impl_outer_origin! {
+		pub enum Origin for Test {}
+	}
+
+	// For testing the pallet, we construct most of a mock runtime. This means
+	// first constructing a configuration type (`Test`) which `impl`s each of the
+	// configuration traits of modules we want to use.
+	#[derive(Clone, Eq, PartialEq)]
+	pub struct Test;
+
+	pub trait Trait: system::Trait {}
+
+	decl_module! {
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		}
+	}
+
+	#[derive(Clone, PartialEq, Encode, Decode, Default)]
+	struct SomeStruct {
+		foo: u16,
+		bar: u32,
+	}
+
+	decl_storage! {
+		trait Store for Module<T: Trait> as RingBufferTest {
+			TestMap get(fn get_test_value): map hasher(twox_64_concat) Index => SomeStruct;
+			TestRange get(fn get_test_range): (Index, Index) = (0, 0);
+		}
+	}
+
+	parameter_types! {
+		pub const BlockHashCount: u64 = 250;
+		pub const MaximumBlockWeight: Weight = 1024;
+		pub const MaximumBlockLength: u32 = 2 * 1024;
+		pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	}
+
+	impl system::Trait for Test {
+		type Origin = Origin;
+		type Call = ();
+		type Index = u64;
+		type BlockNumber = u64;
+		type Hash = H256;
+		type Hashing = BlakeTwo256;
+		type AccountId = u64;
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Header = Header;
+		type Event = ();
+		type BlockHashCount = BlockHashCount;
+		type MaximumBlockWeight = MaximumBlockWeight;
+		type MaximumBlockLength = MaximumBlockLength;
+		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
+		type ModuleToIndex = ();
+		type AccountData = ();
+		type OnNewAccount = ();
+		type OnKilledAccount = ();
+	}
+
+	impl Trait for Test {
+	}
+
+	type System = system::Module<Test>;
+	type TestModule = Module<Test>;
+
+	// This function basically just builds a genesis storage key/value store according to
+	// our desired mockup.
+	fn new_test_ext() -> sp_io::TestExternalities {
+		let mut storage = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		storage.into()
+	}
+
+	// ------------------------------------------------------------
+	// ringbuffer
+
+	type RingBuffer = RingBufferTrait<
+		SomeStruct, <TestModule as Store>::TestRange, <TestModule as Store>::TestMap,
+		Item = SomeStruct, Bounds = <TestModule as Store>::TestRange, Map = <TestModule as Store>::TestMap,
+		Transient = RingBufferTransient>;
+	#[test]
+	fn ringbuffer_test() {
+		new_test_ext().execute_with(|| {
+
+			let ring = RingBufferTransient::from();
+			ring.push(SomeStruct{foo: 1, bar: 2});
+			ring.commit();
+			let start_end = TestModule::get_test_range();
+			assert_eq!(start_end, (0, 1));
+		})
+	}
+
+	// #[test]
+	// fn ringbuffer_pop_bond() {
+	// 	new_test_ext().execute_with(|| {
+	// 		assert_ok!(Stablecoin::init(Origin::signed(1)));
+
+	// 		let start_end = Stablecoin::bonds_range();
+	// 		let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
+	// 		let (start, end) = Stablecoin::push_bond(start_end, Stablecoin::new_bond(2, payout));
+	// 		assert_eq!(start..end, 0..1);
+
+	// 		let ((start, end), bond) = Stablecoin::pop_bond((start, end));
+	// 		assert!(bond.is_some());
+	// 		assert_eq!(start..end, 1..1);
+	// 	})
+	// }
+
+	// #[test]
+	// fn ringbuffer_wrap_around() {
+	// 	new_test_ext().execute_with(|| {
+	// 		assert_ok!(Stablecoin::init(Origin::signed(1)));
+
+	// 		let mut start_end = Stablecoin::bonds_range();
+	// 		let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
+	// 		for i in 1..(u16::max_value() as u64) + 2 {
+	// 			start_end = Stablecoin::push_bond(start_end, Stablecoin::new_bond(i, payout));
+	// 		}
+	// 		assert_eq!(
+	// 			start_end,
+	// 			(1, 0),
+	// 			"range should be inverted because the index wrapped around"
+	// 		);
+
+	// 		let ((start, end), bond) = Stablecoin::pop_bond(start_end);
+	// 		assert_eq!(start..end, 2..0);
+	// 		let bond = bond.expect("a valid bond should be returned");
+	// 		assert_eq!(bond.account, 2, "the bond for account 2, was placed at index 1");
+
+	// 		let ((start, end), bond) = Stablecoin::pop_bond((start, end));
+	// 		assert_eq!(start..end, 3..0);
+	// 		let bond = bond.expect("a valid bond should be returned");
+	// 		assert_eq!(bond.account, 3, "the bond for account 3, was placed at index 2");
+
+	// 		start_end = (start, end);
+	// 		for i in 1..4 {
+	// 			start_end = Stablecoin::push_bond(start_end, Stablecoin::new_bond(i, payout));
+	// 		}
+	// 		assert_eq!(start_end, (4, 3));
+	// 	})
+	// }
+
+	// #[test]
+	// fn ringbuffer_push_front() {
+	// 	new_test_ext().execute_with(|| {
+	// 		assert_ok!(Stablecoin::init(Origin::signed(1)));
+
+	// 		let start_end = Stablecoin::bonds_range();
+	// 		let payout = Fixed64::from_rational(20, 100).saturated_multiply_accumulate(BaseUnit::get());
+	// 		let start_end = Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
+	// 		assert_eq!(start_end, (0, 1));
+
+	// 		let start_end = Stablecoin::push_bond_front(start_end, Stablecoin::new_bond(2, payout));
+	// 		assert_eq!(start_end, (u16::max_value(), 1));
+	// 	})
+	// }
+}

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -133,7 +133,7 @@ mod tests {
 		}
 	}
 
-	#[derive(Clone, PartialEq, Encode, Decode, Default)]
+	#[derive(Clone, PartialEq, Encode, Decode, Default, Debug)]
 	pub struct SomeStruct {
 		foo: u16,
 		bar: u32,
@@ -195,7 +195,7 @@ mod tests {
 		SomeStruct,
 		Item = SomeStruct, Bounds = <TestModule as Store>::TestRange, Map = <TestModule as Store>::TestMap>;
 	#[test]
-	fn ringbuffer_test() {
+	fn simple_push() {
 		new_test_ext().execute_with(|| {
 
 			let mut ring : Box<dyn RingBufferTrait<SomeStruct, Item = SomeStruct, Bounds = <TestModule as Store>::TestRange, Map = <TestModule as Store>::TestMap>> = Box::new(
@@ -209,6 +209,8 @@ mod tests {
 			ring.commit();
 			let start_end = TestModule::get_test_range();
 			assert_eq!(start_end, (0, 1));
+			let some_struct = TestModule::get_test_value(0);
+			assert_eq!(some_struct, SomeStruct{foo: 1, bar: 2});
 		})
 	}
 

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -201,11 +201,11 @@ mod tests {
 	// ------------------------------------------------------------
 	// ringbuffer
 
-	// trait object that we will be interacting with
+	// Trait object that we will be interacting with.
 	type RingBuffer = dyn RingBufferTrait<
 		SomeStruct,
 		Item = SomeStruct, Bounds = <TestModule as Store>::TestRange, Map = <TestModule as Store>::TestMap>;
-	// implementation that we will instantiate
+	// Implementation that we will instantiate.
 	type Transient = RingBufferTransient::<
 		SomeStruct,
 		<TestModule as Store>::TestRange,

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -47,7 +47,7 @@ where
 	I: Codec + EncodeLike,
 	B: StorageValue<(Index, Index), Query = (Index, Index)>,
 	M: StorageMap<Index, I, Query = I>,
-	T: RingBufferTrait<I>,
+	T: RingBufferTrait<I> + ?Sized,
 {
 	type Item = I;
 	type Bounds = B;
@@ -134,7 +134,7 @@ mod tests {
 	}
 
 	#[derive(Clone, PartialEq, Encode, Decode, Default)]
-	struct SomeStruct {
+	pub struct SomeStruct {
 		foo: u16,
 		bar: u32,
 	}
@@ -198,7 +198,7 @@ mod tests {
 	fn ringbuffer_test() {
 		new_test_ext().execute_with(|| {
 
-			let ring : Box<dyn RingBufferTrait<SomeStruct, Item = SomeStruct, Bounds = <TestModule as Store>::TestRange, Map = <TestModule as Store>::TestMap>> = Box::new(
+			let mut ring : Box<dyn RingBufferTrait<SomeStruct, Item = SomeStruct, Bounds = <TestModule as Store>::TestRange, Map = <TestModule as Store>::TestMap>> = Box::new(
 				RingBufferTransient::<
 					RingBuffer, 
 					SomeStruct,

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -1,3 +1,34 @@
+//! # Transient RingBuffer implementation
+//!
+//! This module provides a trait and implementation for a ringbuffer that
+//! abstracts over storage items and presents them as a FIFO queue.
+//!
+//! Usage Example:
+//! ```rust,ignore
+//! use ringbuffer::{RingBufferTrait, RingBufferTransient};
+//!
+//! // Trait object that we will be interacting with.
+//! type RingBuffer = dyn RingBufferTrait<
+//!     SomeStruct,
+//!     Bounds = <TestModule as Store>::TestRange,
+//!     Map = <TestModule as Store>::TestMap,
+//! >;
+//! // Implementation that we will instantiate.
+//! type Transient = RingBufferTransient<
+//!     SomeStruct,
+//!     <TestModule as Store>::TestRange,
+//!     <TestModule as Store>::TestMap,
+//!     RingBuffer,
+//! >;
+//! {
+//!     let mut ring: Box<RingBuffer> = Box::new(Transient::new());
+//!     ring.push(SomeStruct { foo: 1, bar: 2 });
+//! } // `ring.commit()` will be called on `drop` here and syncs to storage
+//! ```
+//!
+//! Note: You might want to introduce a helper function that wraps the complex
+//! types and just returns the boxed trait object.
+
 use codec::{Codec, EncodeLike};
 use core::marker::PhantomData;
 use frame_support::storage::{StorageMap, StorageValue};


### PR DESCRIPTION
This PR implements an experimental "storage adapter" (still looking for a good name) that wraps a number of Storage items and offers a different interface.

This particular interface is a RingBuffer FIFO queue implemented on top of a `StorageMap<u16, Item>` and a `StorageValue<(u16, u16)>`.