### PR TITLE
Implement ORML BasicCurrency trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-stablecoin"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["apopiak"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ sp-io = { default-features = false, version = '2.0.0-alpha.3' }
 sp-runtime = { default-features = false, version = '2.0.0-alpha.3' }
 sp-std = { default-features = false, version = '2.0.0-alpha.3' }
 system = { default-features = false, package = 'frame-system', version = '2.0.0-alpha.3' }
+# orml
+orml-traits = { default-features = false, git = 'https://github.com/laminar-protocol/open-runtime-module-library.git' }
 # optional deps
 serde = { features = ['derive'], optional = true, version = '1.0.101' }
 


### PR DESCRIPTION
This PR implements the `BasicCurrency` trait from [ORML](https://github.com/laminar-protocol/open-runtime-module-library) to show how this stablecoin might be made interoperable with other pallets.